### PR TITLE
Strip whitespace to get better match rates

### DIFF
--- a/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
+++ b/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
@@ -277,7 +277,7 @@ class Command(BaseCommand):
                             #except:
                                 #pass
 
-                            data = {
+                            data = self.strip_dict({
                                     'intro': intro.replace('<b>','').replace('</b>',''),
                                     'question': question.replace('&#204;',''),
                                     'number2': number2,
@@ -291,7 +291,7 @@ class Command(BaseCommand):
                                     'parliament': parliament,
                                     'house': house,
                                     'type': questiontype
-                                    }
+                                    })
                             # self.stdout.write("Writing object %s\n" % str(data))
                             q = Question.objects.create( **data )
                             self.stdout.write("Wrote question #%d\n" % q.id)
@@ -332,6 +332,7 @@ class Command(BaseCommand):
                     break
             else:
                 self.stderr.write('Adding answer for {0}\n'.format(detail['url']))
+                detail = self.strip_dict(detail)
                 answer = Answer.objects.create(**detail)
 
             if options['limit'] and count >= options['limit']:
@@ -546,3 +547,5 @@ class Command(BaseCommand):
         self.stdout.write('Imported %d / %d sections\n' %
             (len(sections), len(questions)))
 
+    def strip_dict(self, d):
+        return { k: v.strip() for k,v in d.items() }


### PR DESCRIPTION
Some of the match failures were simply because the parser included whitespace in the ids... this should be a quick fix for that.

(Issuing PR to discuss with Mark, but I don't remember what kind of difference this made, nor whether it required additional testing / test-fixes etc.)
