### PR TITLE
Update SayIt import function to use ZA specific subclass.

### DIFF
--- a/za_hansard/management/commands/za_hansard_load_into_sayit.py
+++ b/za_hansard/management/commands/za_hansard_load_into_sayit.py
@@ -4,7 +4,7 @@ import pytz
 import time
 import sys
 
-from speeches.importers.import_akomantoso import ImportAkomaNtoso
+from speeches.importers.import_za_akomantoso import ImportZAAkomaNtoso
 from speeches.models import Section, Tag
 from za_hansard.models import Source
 from popit.models import ApiInstance
@@ -64,7 +64,7 @@ class Command(BaseCommand):
             if not path:
                 continue
 
-            importer = ImportAkomaNtoso( instance=instance,
+            importer = ImportZAAkomaNtoso( instance=instance,
                 popit_url='http://za-peoples-assembly.popit.mysociety.org/api/v0.1/')
             try:
                 self.stdout.write("TRYING %s\n" % path)


### PR DESCRIPTION
SayIt now has a specific AkomaNtoso subclass for importing this non-standard ZA data. This switches to using it, so that the tests continue to pass on the current master branch of SayIt.
