### PR TITLE
Don't attribute speeches to Madoda Sambatha or Beryl Belinda Miller

### DIFF
--- a/za_hansard/management/commands/za_hansard_pmg_api_scraper.py
+++ b/za_hansard/management/commands/za_hansard_pmg_api_scraper.py
@@ -615,7 +615,11 @@ class Command(BaseCommand):
                     delete_existing=options['delete_existing'],
                     popit_url='http://za-new-import.popit.mysociety.org/api/v0.1/',
                     commit=options['commit'],
-                    popit_id_blacklist=('core_person:5421',),
+                    popit_id_blacklist=(
+                        'core_person:3739',
+                        'core_person:4555',
+                        'core_person:5421',
+                        ),
                 )
                 try:
                     message = "Importing {0} ({1})\n"

--- a/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
+++ b/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
@@ -23,7 +23,6 @@ from za_hansard.importers.import_json import ImportJson
 from instances.models import Instance
 
 from speeches.models import Section, Speaker, Speech
-from pombola.slug_helpers.models import SlugRedirect
 from django.contrib.contenttypes.models import ContentType
 
 # ideally almost all of the parsing code would be removed from this management
@@ -570,6 +569,10 @@ class Command(BaseCommand):
                             speech.speaker = new_speaker
                             speech.save()
 
+                    # If this is a top level import, it will break the
+                    # za-hansard tests when run in isolation (i.e. not
+                    # as part of Pombola)
+                    from pombola.slug_helpers.models import SlugRedirect
                     SlugRedirect.objects.create(
                         content_type=ContentType.objects.get_for_model(Section),
                         old_object_slug=section.get_path,


### PR DESCRIPTION
Blacklist Madoda Sambatha and Beryl Belinda Miller so that they
no longer get speeches associated with them.

Fixes mysociety/pombola#1718 (along with some data fixes)