### PR TITLE
Fix decoding errors: self.stdout.write needs a unicode or 7-bit ASCII

### DIFF
--- a/za_hansard/management/commands/za_hansard_pmg_api_scraper.py
+++ b/za_hansard/management/commands/za_hansard_pmg_api_scraper.py
@@ -300,7 +300,7 @@ class Command(BaseCommand):
 
     def handle_committee(self, committee):
         self.stdout.write("=======================================\n")
-        self.stdout.write(u"handling committee: {0}\n".format(committee['name']).encode('utf-8'))
+        self.stdout.write(u"handling committee: {0}\n".format(committee['name']))
         full_committee_results = get_authenticated_json(committee['url'])
 
         if 'events' not in full_committee_results:
@@ -310,7 +310,7 @@ class Command(BaseCommand):
         for i, event in enumerate(full_committee_results['events']):
             if not (self.process_all_meetings or self.specified_meeting(event['id'])):
                 continue
-            self.stdout.write(u"committee {0}\n".format(committee['name']).encode('utf-8'))
+            self.stdout.write(u"committee {0}\n".format(committee['name']))
             msg = "api_committee_id {0} api_meeting_id {1}\n"
             self.stdout.write(msg.format(committee['id'], event['id']))
             meeting_report = self.get_meeting_report(
@@ -397,7 +397,7 @@ class Command(BaseCommand):
             )
             for name_match in chairperson_name_matches:
                 full_name = format_name_match(name_match)
-                self.stdout.write(u"  chair => {0}\n".format(full_name).encode('utf-8'))
+                self.stdout.write(u"  chair => {0}\n".format(full_name))
 
         def get_appearance(text, name='', party='', chair=False, **kwargs):
             """Create a new apperance and indicate that on the console"""
@@ -405,7 +405,7 @@ class Command(BaseCommand):
                 'chairperson ' if chair else '',
                 name,
                 party,
-            ).encode('utf-8'))
+            ))
             return PMGCommitteeAppearance(
                 report=meeting_report,
                 party=party,


### PR DESCRIPTION
self.stdout.write tests to see if the message that's being written ends
with u'\n' (i.e. a unicode). It does that with .endswith,
which fails with a UnicodeDecodeError if the message is a str that
contains top bit set octets. It calls force_str on the message before
actually writing so it works fine when passed a unicode.